### PR TITLE
fix reward settings

### DIFF
--- a/get_reward.py
+++ b/get_reward.py
@@ -12,6 +12,8 @@ BUFFER_NORM_FACTOR = 10.0
 CHUNK_TIL_VIDEO_END_CAP = 48.0
 M_IN_K = 1000.0
 REBUF_PENALTY = 4.3  # 1 sec rebuffering -> 3 Mbps
+LOG_REBUF_PENALTY = 2.66  # 1 sec rebuffering -> 3 Mbps
+HD_REBUF_PENALTY = 8  # 1 sec rebuffering -> 3 Mbps
 SMOOTH_PENALTY = 1
 DEFAULT_QUALITY = 1  # default video quality without agent
 RANDOM_SEED = 42
@@ -25,9 +27,9 @@ def get_reward(bit_rate, rebuf, last_bit_rate, reward_type):
     elif reward_type == 'log':
         log_bit_rate = np.log(VIDEO_BIT_RATE[bit_rate] / float(VIDEO_BIT_RATE[-1]))
         log_last_bit_rate = np.log(VIDEO_BIT_RATE[last_bit_rate] / float(VIDEO_BIT_RATE[-1]))
-        reward = log_bit_rate - REBUF_PENALTY * rebuf - REBUF_PENALTY * np.abs(log_bit_rate - log_last_bit_rate)
+        reward = log_bit_rate - LOG_REBUF_PENALTY * rebuf - SMOOTH_PENALTY * np.abs(log_bit_rate - log_last_bit_rate)
     elif reward_type == 'hd':
-        reward = HD_REWARD[bit_rate] - REBUF_PENALTY * rebuf - \
+        reward = HD_REWARD[bit_rate] - HD_REBUF_PENALTY * rebuf - \
                  SMOOTH_PENALTY * np.abs(HD_REWARD[bit_rate] - HD_REWARD[last_bit_rate])
     else:
         raise NotImplementedError


### PR DESCRIPTION
Adjusted the reward settings based on the original Pensieve paper, including QoE_log and QoE_HD.

Note: This change will not affect the key contributions of PiTree.